### PR TITLE
Missing -c when compiling tissue.cpp

### DIFF
--- a/Makefile_CyCells
+++ b/Makefile_CyCells
@@ -165,4 +165,4 @@ tissue.o: tissue.cpp tissue.h \
 		molecule.h \
 		random.h \
 		util.h
-	$(CXX) $(CXXFLAGS) tissue.cpp
+	$(CXX) -c $(CXXFLAGS) tissue.cpp


### PR DESCRIPTION
Missing -c causes the compiler to look for a main function when compiling tissue on CentOS:

g++ -pipe -O2 -Wall -W -D_REENTRANT -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED tissue.cpp
/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../lib64/crt1.o: In function `_start':
(.text+0x20): undefined reference to `main'

Fixed by adding the -c